### PR TITLE
Add missing capistrano/rails dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ If your application is not prepared for capistrano yet, you need to do so now:
 
     $ bundle exec cap install
 
-You have to add the `Capistrano::Alchemy` tasks to your `Capfile`
+You have to add the `Capistrano::Alchemy` and Rails specific tasks to your `Capfile`
 
 ```ruby
+require 'capistrano/rails' 
 require 'capistrano/alchemy'
 ```
 

--- a/capistrano-alchemy.gemspec
+++ b/capistrano-alchemy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", "~> 3.0"
-
+  spec.add_dependency "capistrano-rails", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'alchemy_cms', "~> 3.0"


### PR DESCRIPTION
Without it  

```ruby
bundle exec cap -T alchemy --trace
```

results in error:

```
Don't know how to build task 'migrate'
...
/bundler/gems/capistrano-alchemy-32fe99ee5b0c/lib/capistrano/tasks/alchemy_capistrano_hooks.rake:7:in `<top (required)>'
/bundler/gems/capistrano-alchemy-32fe99ee5b0c/lib/capistrano/alchemy.rb:15:in `load'
/bundler/gems/capistrano-alchemy-32fe99ee5b0c/lib/capistrano/alchemy.rb:15:in `<top (required)>'
```