### PR TITLE
Remove the explicit capistrano dependency.

### DIFF
--- a/capistrano-alchemy.gemspec
+++ b/capistrano-alchemy.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", "~> 3.0"
   spec.add_dependency "capistrano-rails", "~> 1.1"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'alchemy_cms', "~> 3.0"


### PR DESCRIPTION
`capistrano-rails` already depends on `capistrano`, `~> 3.1`, so we don't need to explicitly depend on it.