### PR TITLE
Fix assets linking path

### DIFF
--- a/lib/capistrano/tasks/alchemy.rake
+++ b/lib/capistrano/tasks/alchemy.rake
@@ -11,7 +11,7 @@ namespace :alchemy do
       "uploads/pictures",
       "uploads/attachments",
       fetch(:alchemy_picture_cache_path),
-      "tmp/cache/assets"
+      "public/assets"
     ]
 
     # TODO: Check, if this is the right approach to ensure that we don't overwrite existing settings?


### PR DESCRIPTION
Assets in ```shared_path``` results in circular link without this fix. For example:

```/var/www/project/shared/tmp/cache/assets -> /var/www/project/shared/tmp/cache/assets```

The path in ```/var/www/project/current/public/assets``` will stay intact for that case. This is not the expected behaviour.