### PR TITLE
Add spinner.rb dependency because AlchemyCMS drops it

### DIFF
--- a/capistrano-alchemy.gemspec
+++ b/capistrano-alchemy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano-rails", "~> 1.1"
+  spec.add_dependency 'spinner.rb'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Spinner.rb is only used here, so it makes sense to add the dependency here.