### PR TITLE
Symlink complete uploads folder

### DIFF
--- a/lib/capistrano/tasks/alchemy.rake
+++ b/lib/capistrano/tasks/alchemy.rake
@@ -5,8 +5,7 @@ namespace :alchemy do
     set :alchemy_picture_cache_path,
       -> { File.join('public', Alchemy::MountPoint.get, 'pictures') }
     set :linked_dirs, fetch(:linked_dirs, []) + [
-      "uploads/pictures",
-      "uploads/attachments",
+      "uploads",
       fetch(:alchemy_picture_cache_path)
     ]
   end


### PR DESCRIPTION
In order to have always all types of uploads some one stores in the
uploads folder and to prevent rsync issues it is best to symlink the complete
uploads folder instead of each folder inside.