### PR TITLE
Add alchemy_picture_cache_path setting

### DIFF
--- a/lib/capistrano/tasks/alchemy.rake
+++ b/lib/capistrano/tasks/alchemy.rake
@@ -2,8 +2,11 @@ namespace :alchemy do
 
   # Prepare Alchemy for deployment
   task :default_paths do
-    set :alchemy_picture_cache_path,
-      -> { File.join('public', Alchemy::MountPoint.get, 'pictures') }
+    unless fetch(:alchemy_picture_cache_path)
+      set :alchemy_picture_cache_path, -> {
+        File.join('public', Alchemy::MountPoint.get, 'pictures')
+      }
+    end
     set :linked_dirs, fetch(:linked_dirs, []) + [
       "uploads",
       fetch(:alchemy_picture_cache_path)


### PR DESCRIPTION
Allow the host app to override the `alchemy_picture_cache_path` setting, so that it does not have to always rely on the `Alchemy::MountPoint`