### PR TITLE
Do not link the picture cache folder

### DIFF
--- a/lib/capistrano/alchemy.rb
+++ b/lib/capistrano/alchemy.rb
@@ -2,10 +2,6 @@ require "capistrano/alchemy/version"
 
 require 'fileutils'
 require 'alchemy/tasks/helpers'
-# Loading the rails app
-# require './config/environment.rb'
-# so we can read the current mount point of Alchemy
-require 'alchemy/mount_point'
 require 'capistrano/alchemy/deploy_support'
 
 include Alchemy::Tasks::Helpers
@@ -13,4 +9,3 @@ include Capistrano::Alchemy::DeploySupport
 
 load File.expand_path('../tasks/alchemy.rake', __FILE__)
 load File.expand_path('../tasks/alchemy_capistrano_hooks.rake', __FILE__)
-

--- a/lib/capistrano/tasks/alchemy.rake
+++ b/lib/capistrano/tasks/alchemy.rake
@@ -2,12 +2,7 @@ namespace :alchemy do
 
   # Prepare Alchemy for deployment
   task :default_paths do
-    set :alchemy_picture_cache_path,
-      -> { File.join('public', Alchemy::MountPoint.get, 'pictures') }
-    set :linked_dirs, fetch(:linked_dirs, []) + [
-      "uploads",
-      fetch(:alchemy_picture_cache_path)
-    ]
+    set :linked_dirs, fetch(:linked_dirs, []) + %w(uploads)
   end
 
   namespace :db do


### PR DESCRIPTION
The picture cache folder was recently removed in Alchemy 3.5